### PR TITLE
Support for reading multiple gzip entries in a single stream.

### DIFF
--- a/zlibnet/zlib/ZLib.cs
+++ b/zlibnet/zlib/ZLib.cs
@@ -107,7 +107,33 @@ namespace ZLibNet
 				return deflateEnd_32(ref strm);
 		}
 
-		[DllImport(ZLibDll.Name32, EntryPoint = "crc32", ExactSpelling = true)]
+	    [DllImport(ZLibDll.Name32, EntryPoint = "deflateReset", ExactSpelling = true)]
+	    static extern int deflateReset_32(ref z_stream strm);
+	    [DllImport(ZLibDll.Name64, EntryPoint = "deflateReset", ExactSpelling = true)]
+	    static extern int deflateReset_64(ref z_stream strm);
+
+	    internal static int deflateReset(ref z_stream strm)
+	    {
+	        if (ZLibDll.Is64)
+	            return deflateReset_64(ref strm);
+	        else
+	            return deflateReset_32(ref strm);
+	    }
+
+	    [DllImport(ZLibDll.Name32, EntryPoint = "inflateReset", ExactSpelling = true)]
+	    static extern int inflateReset_32(ref z_stream strm);
+	    [DllImport(ZLibDll.Name64, EntryPoint = "inflateReset", ExactSpelling = true)]
+	    static extern int inflateReset_64(ref z_stream strm);
+
+	    internal static int inflateReset(ref z_stream strm)
+	    {
+	        if (ZLibDll.Is64)
+	            return inflateReset_64(ref strm);
+	        else
+	            return inflateReset_32(ref strm);
+	    }
+
+        [DllImport(ZLibDll.Name32, EntryPoint = "crc32", ExactSpelling = true)]
 		static extern uint crc32_32(uint crc, IntPtr buffer, uint len);
 		[DllImport(ZLibDll.Name64, EntryPoint = "crc32", ExactSpelling = true)]
 		static extern uint crc32_64(uint crc, IntPtr buffer, uint len);

--- a/zlibnet/zlib/ZLibStreams.cs
+++ b/zlibnet/zlib/ZLibStreams.cs
@@ -162,9 +162,23 @@ namespace ZLibNet
 
 						if (zlibError == ZLibReturnCode.StreamEnd)
 						{
-							pWorkDataPos = -1; // magic for StreamEnd
-							break;
-						}
+						    if (OpenType == ZLibOpenType.GZip && BaseStream.Position < BaseStream.Length)
+						    {
+						        zlibError = ZLib.inflateReset(ref pZstream); // Reset for next gzip record, if any
+
+						        if (zlibError != ZLibReturnCode.Ok)
+						        {
+						            pWorkDataPos = -1;
+						            break;
+						        }
+                            }
+						    else
+						    {
+						        pWorkDataPos = -1; // magic for StreamEnd
+						        break;
+                            }
+                        }
+
 						else if (zlibError != ZLibReturnCode.Ok)
 						{
 							pSuccess = false;


### PR DESCRIPTION
The GZIP spec specifies that multiple GZIP records can be concatenated into a single file. This commit updates DeflateStream to reset the zlib stream after StreamEnd so that the subsequent read operation will open the next GZIP record. 